### PR TITLE
Added pair combinator

### DIFF
--- a/opal.ml
+++ b/opal.ml
@@ -82,6 +82,7 @@ let (=>) x f = x >>= fun r -> return (f r)
 let (>>) x y = x >>= fun _ -> y
 let (<<) x y = x >>= fun r -> y >>= fun _ -> return r
 let (<~>) x xs = x >>= fun r -> xs >>= fun rs -> return (r :: rs)
+let (<~~>) x y = x >>= fun r -> y >>= fun rs -> return (r,rs)
 
 let rec choice = function
   | [] -> mzero


### PR DESCRIPTION
Instead of using `>>=` as a generic but a bit cumbersome way to work with tuples of arbitrary length, you can use `<~~>` to pair up combinators. 
