### PR TITLE
Added cmx to libinstall target. Fixed small error in none_of.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SOURCES = opal.ml
 RESULT = opal
-LIBINSTALL_FILES = META opal.cma opal.cmxa opal.cmi opal.a
+LIBINSTALL_FILES = META opal.cma opal.cmxa opal.cmx opal.cmi opal.a
 
 all: ncl bcl
 

--- a/opal.ml
+++ b/opal.ml
@@ -124,7 +124,7 @@ let chainr x op default = chainr1 x op <|> return default
 
 let exactly x = satisfy ((=) x)
 let one_of  l = satisfy (fun x -> List.mem x l)
-let none_of l = satisfy (fun x -> not (List.mem l x))
+let none_of l = satisfy (fun x -> not (List.mem x l))
 let range l r = satisfy (fun x -> l <= x && x <= r)
 
 (* char parsers ------------------------------------------------------------- *)


### PR DESCRIPTION
The missing cmx was causing a warning when the package was used with ocamlfind. I just added it in the Makefile and the warning seems to disappear.

The error in none_of compiled but produced the wrong function type. I assume this was an error and not intentional? If intentional I don't understand the function type.