### PR TITLE
Added an mli file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+._bcdi/
+._ncdi/
 _build/*
 .ocamlinit
 *.byte

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SOURCES = opal.ml
+SOURCES = opal.mli opal.ml
 RESULT = opal
 LIBINSTALL_FILES = META opal.cma opal.cmxa opal.cmx opal.cmi opal.a
 

--- a/opal.ml
+++ b/opal.ml
@@ -138,7 +138,7 @@ let lower     = range 'a' 'z'
 let digit     = range '0' '9'
 let letter    = lower  <|> upper
 let alpha_num = letter <|> digit
-let hex_digit = range 'a' 'f' <|> range 'A' 'F'
+let hex_digit = range 'a' 'f' <|> range 'A' 'F' <|> digit
 let oct_digit = range '0' '7'
 
 (* lex helper --------------------------------------------------------------- *)

--- a/opal.mli
+++ b/opal.mli
@@ -1,0 +1,79 @@
+module LazyStream :
+  sig
+    type 'a t = Cons of 'a * 'a t Lazy.t | Nil
+    val of_stream : 'a Stream.t -> 'a t
+    val of_function : (unit -> 'a option) -> 'a t
+    val of_string : string -> char t
+    val of_channel : in_channel -> char t
+  end
+
+val implode : char list -> string
+val explode : string -> char list
+val ( % ) : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c
+
+type ('token, 'result) parser
+val parse : ('token, 'a) parser -> 'token LazyStream.t -> 'a option
+
+val return : 'a -> ('token, 'a) parser
+val ( >>= ) :
+  ('token, 'a) parser -> ('a -> ('token, 'b) parser) -> ('token, 'b) parser
+val ( <|> ) : ('token, 'a) parser -> ('token, 'a) parser -> ('token, 'a) parser
+val scan : ('token, 'a) parser -> 'token LazyStream.t -> 'a LazyStream.t
+val mzero : ('token, 'a) parser
+val any : ('token, 'token) parser
+val satisfy : ('token -> bool) -> ('token, 'token) parser
+val eof : 'a -> ('token, 'a) parser
+
+val ( => ) : ('token, 'a) parser -> ('a -> 'b) -> ('token, 'b) parser
+val ( << ) : ('token, 'a) parser -> ('token, 'b) parser -> ('token, 'a) parser
+val ( >> ) : ('token, 'a) parser -> ('token, 'b) parser -> ('token, 'b) parser
+val ( <~> ) :
+  ('token, 'a) parser -> ('token, 'a list) parser -> ('token, 'a list) parser
+
+val choice : ('token, 'a) parser list -> ('token, 'a) parser
+val count : int -> ('token, 'a) parser -> ('token, 'a list) parser
+val between :
+  ('token, 'a) parser -> ('token, 'b) parser ->
+  ('token, 'c) parser -> ('token, 'c) parser
+val option : 'a -> ('token, 'a) parser -> ('token, 'a) parser
+val optional : ('token, 'a) parser -> ('token, unit) parser
+val skip_many1 : ('token, 'a) parser -> ('token, unit) parser
+val skip_many : ('token, 'a) parser -> ('token, unit) parser
+val many1 : ('token, 'a) parser -> ('token, 'a list) parser
+val many : ('token, 'a) parser -> ('token, 'a list) parser
+val sep_by1 :
+  ('token, 'a) parser -> ('token, 'b) parser -> ('token, 'a list) parser
+val sep_by :
+  ('token, 'a) parser -> ('token, 'b) parser -> ('token, 'a list) parser
+val end_by1 :
+  ('token, 'a) parser -> ('token, 'b) parser -> ('token, 'a list) parser
+val end_by :
+  ('token, 'a) parser -> ('token, 'b) parser -> ('token, 'a list) parser
+val chainl1 :
+  ('token, 'a) parser -> ('token, 'a -> 'a -> 'a) parser -> ('token, 'a) parser
+val chainl :
+  ('token, 'a) parser -> ('token, 'a -> 'a -> 'a) parser -> 'a -> ('token, 'a) parser
+val chainr1 :
+  ('token, 'a) parser -> ('token, 'a -> 'a -> 'a) parser -> ('token, 'a) parser
+val chainr :
+  ('token, 'a) parser -> ('token, 'a -> 'a -> 'a) parser -> 'a -> ('token, 'a) parser
+
+val exactly : 'token -> ('token, 'token) parser
+val one_of : 'token list -> ('token, 'token) parser
+val none_of : 'token list -> ('token, 'token) parser
+val range : 'token -> 'token -> ('token, 'token) parser
+
+val space : (char, char) parser
+val spaces : (char, unit) parser
+val newline : (char, char) parser
+val tab : (char, char) parser
+val upper : (char, char) parser
+val lower : (char, char) parser
+val digit : (char, char) parser
+val letter : (char, char) parser
+val alpha_num : (char, char) parser
+val hex_digit : (char, char) parser
+val oct_digit : (char, char) parser
+
+val lexeme : (char, 'a) parser -> (char, 'a) parser
+val token : string -> (char, string) parser


### PR DESCRIPTION
I made the type of parser opaque but maybe you don't want to do that? I did not touch the .ml file so it still works to copy/paste it. The mli makes it more usable as a OPAM package I think, since it restricts the types and makes it easier to see what the functions do from the types alone.

I also changed hex_digit so it also parses digits 0-9, matching the Parsec behavior.
