### PR TITLE
Add support for the let syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,20 @@ Accepts a value and an input, and returns a monad.
 `x >>= f` returns a new parser that if parser `x` succeeds, applies function `f` 
 on monad produced by `x`, and produces a new monad (a.k.a. `bind`).
 
+**`val ( let* ) : ('t, 'r) parser -> ('r -> ('t, 'r) monad) -> ('t, 'r) parser`**
+
+This operator is the same as `>>=` but using the `let` notation.
+It is usefull to avoid ugly sequences of bindings. For exemple, `p >>= fun x -> f x` can
+be rewritten `let* x = p in f x`. Combined with the `return` function, we can define complex parsers :
+
+```ocaml
+let tuple_parser =
+  let* x = digit in
+  let* _ = exactly ',' in
+  let* y = digit in
+  return (x, y)
+```
+
 **`val ( <|> ) : ('t, 'r) parser -> ('t, 'r) parser -> ('t, 'r) parser`**
 
 Choice combinator. The parser `p <|> q` first applies `q`. If it succeeds, the

--- a/opal.ml
+++ b/opal.ml
@@ -48,15 +48,17 @@ let return x input = Some(x, input)
 
 let (>>=) x f =
   fun input ->
-    match x input with
-    | Some(result', input') -> f result' input'
-    | None -> None
+  match x input with
+  | Some(result', input') -> f result' input'
+  | None -> None
+
+let (let*) = (>>=)
 
 let (<|>) x y =
   fun input ->
-    match x input with
-    | Some _ as ret -> ret
-    | None -> y input
+  match x input with
+  | Some _ as ret -> ret
+  | None -> y input
 
 let rec scan x input =
   match x input with

--- a/opal.mli
+++ b/opal.mli
@@ -1,11 +1,11 @@
 module LazyStream :
-  sig
-    type 'a t = Cons of 'a * 'a t Lazy.t | Nil
-    val of_stream : 'a Stream.t -> 'a t
-    val of_function : (unit -> 'a option) -> 'a t
-    val of_string : string -> char t
-    val of_channel : in_channel -> char t
-  end
+sig
+  type 'a t = Cons of 'a * 'a t Lazy.t | Nil
+  val of_stream : 'a Stream.t -> 'a t
+  val of_function : (unit -> 'a option) -> 'a t
+  val of_string : string -> char t
+  val of_channel : in_channel -> char t
+end
 
 val implode : char list -> string
 val explode : string -> char list
@@ -16,6 +16,8 @@ val parse : ('token, 'a) parser -> 'token LazyStream.t -> 'a option
 
 val return : 'a -> ('token, 'a) parser
 val ( >>= ) :
+  ('token, 'a) parser -> ('a -> ('token, 'b) parser) -> ('token, 'b) parser
+val ( let* ) :
   ('token, 'a) parser -> ('a -> ('token, 'b) parser) -> ('token, 'b) parser
 val ( <|> ) : ('token, 'a) parser -> ('token, 'a) parser -> ('token, 'a) parser
 val scan : ('token, 'a) parser -> 'token LazyStream.t -> 'a LazyStream.t

--- a/opam
+++ b/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/pyrocat101/opal"
 bug-reports: "https://github.com/pyrocat101/opal/issues"
 license: "MIT"
 dev-repo: "https://github.com/pyrocat101/opal.git"
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.08.0" ]
 build: [
   ["%{make}%" "ncl" "bcl"]
 ]


### PR DESCRIPTION
Hello,

I'm a great fan of parser combinators, and this mini lib is very useful. Since ocaml 4.08, it is possible to define custom binding operators using the *let* syntax, I thought it was a good idea to integrate it in Opal. This is just one line, but it makes a huge difference in the code readability when it comes to develop complex parsers.