### PR TITLE
fixed typo in documentation of choice (<|>) combinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ let tuple_parser =
 
 **`val ( <|> ) : ('t, 'r) parser -> ('t, 'r) parser -> ('t, 'r) parser`**
 
-Choice combinator. The parser `p <|> q` first applies `q`. If it succeeds, the
+Choice combinator. The parser `p <|> q` first applies `p`. If it succeeds, the
 value of `p` is returned. If `p` fails, parser `q` is tried.
 
 **`val mzero : 'a -> ('t, 'r) monad`**


### PR DESCRIPTION
simple typo in the documentation for the choice combinator `<|>`, which currently states that the parser `q` is initially tried in the expression `p <|> q`. this has been corrected to `p`.