### PR TITLE
Add Dune integration

### DIFF
--- a/dune
+++ b/dune
@@ -1,0 +1,7 @@
+(library
+ (public_name opal)
+ (libraries camlp-streams))
+
+(env
+ (dev
+  (flags (:standard -warn-error -A))))

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.6)
+(lang dune 2.9)
 
 (name opal)
 (version 0.1.1)

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,25 @@
+(lang dune 3.6)
+
+(name opal)
+(version 0.1.1)
+
+(generate_opam_files false)
+
+(source
+ (github pyrocat101/opal))
+
+(authors "Linjie Ding <i@pyroc.at>")
+
+(maintainers "Linjie Ding <i@pyroc.at>")
+
+(license MIT)
+
+(documentation https://github.com/pyrocat101/opal)
+
+(package
+ (name opal)
+ (synopsis "Self-contained monadic parser combinators for OCaml")
+ (description "Opal is a minimum collection of useful parsers and combinators (~150 loc of OCaml) that makes writing parsers easier. It is designed to be small, self-contained, pure-functional, and only includes most essential parsers, so that one could include single file in the project or just embed it in other OCaml source code files.")
+ (depends camlp-streams ocamlfind)
+ (tags
+  (topics "parser" "combinator")))

--- a/opal.mli
+++ b/opal.mli
@@ -11,8 +11,9 @@ val implode : char list -> string
 val explode : string -> char list
 val ( % ) : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c
 
-type ('token, 'result) parser
-val parse : ('token, 'a) parser -> 'token LazyStream.t -> 'a option
+type 'token input = 'token LazyStream.t
+type ('token, 'result) parser = 'token input -> ('result * 'token input) option
+val parse : ('token, 'a) parser -> 'token input -> 'a option
 
 val return : 'a -> ('token, 'a) parser
 val ( >>= ) :


### PR DESCRIPTION
- Added dune files based on merging the existing OPAM configuration with the auto-generated `dune-project` file
- Fixed the `parser` type definition in `opam.mli`
    + The example listed in the README does not work without this fix (when using this library via dune, at least)